### PR TITLE
Work with older rust versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rust:
   - nightly
   - beta
   - stable
-  - 1.17.0 # currently oldest supported version
+  - 1.13.0 # currently oldest supported version
 script:
   - cargo build --verbose
   - cargo test --verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,3 @@
 
 - improved performance (https://github.com/cardoe/stderrlog-rs/pull/2)
 - improved docopt example in README
-- bumped minimum version to 1.17.0


### PR DESCRIPTION
This should allow the crate to work with older rusts (at least back to 1.15.1, as required)