### PR TITLE
Updates for log 0.4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ rust:
   - nightly
   - beta
   - stable
-  - 1.16.0 # currently oldest supported version, but structopt example fails to build until 1.22.1 so skip tests
+  - 1.20.0 # currently oldest supported version, but structopt example fails to build until 1.22.1 so skip tests
 script:
   - cargo build --verbose
-  - if [ ${TRAVIS_RUST_VERSION} != "1.16.0" ]; then
+  - if [ ${TRAVIS_RUST_VERSION} != "1.20.0" ]; then
         cargo test --verbose;
     fi
   - if [ ${TRAVIS_RUST_VERSION} = "nightly" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## 0.4.0
+
+### Changed
+
+- Now depends on log 0.4.1.
+
 ## 0.3.1
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.3.1-pre"
 
 [dependencies]
 chrono = "0.4"
-log = "0.3"
+log = { version = "0.4.1", features = ["std"] }
 termcolor = "0.3.3"
 thread_local = "0.3"
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build status](https://travis-ci.org/cardoe/stderrlog-rs.svg?branch=master)](https://travis-ci.org/cardoe/stderrlog-rs)
-[![Rust version]( https://img.shields.io/badge/rust-1.16+-blue.svg)]()
+[![Rust version]( https://img.shields.io/badge/rust-1.20+-blue.svg)]()
 [![Documentation](https://docs.rs/stderrlog/badge.svg)](https://docs.rs/stderrlog)
 [![Latest version](https://img.shields.io/crates/v/stderrlog.svg)](https://crates.io/crates/stderrlog)
 [![All downloads](https://img.shields.io/crates/d/stderrlog.svg)](https://crates.io/crates/stderrlog)
@@ -21,6 +21,7 @@ For example binaries showing how
 
 ## Supported Versions
 
+`stderrlog` 0.4.x supports 1) Rust 1.20.0 and newer 2) `log` 0.4.x
 `stderrlog` 0.3.x supports 1) Rust 1.16.0 and newer 2) `log` 0.3.x
 `stderrlog` 0.2.x supports 1) Rust 1.13.0 and newer 2) `log` >= 0.3.0,  < 0.3.9
 
@@ -30,7 +31,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-stderrlog = "0.3"
+stderrlog = "0.4"
 ```
 
 and this to your crate root:

--- a/benches/common/mod.rs
+++ b/benches/common/mod.rs
@@ -19,7 +19,12 @@ fn complex_format(b: &mut Bencher) {
     init_logger();
     with_redirected_stderr(panic::AssertUnwindSafe(|| {
         b.iter(|| {
-            debug!("{}, {:#?}, {:b}", 0.1f64, vec![99, 1, 5, 100, 1, 0, 8], 0xffb1aa)
+            debug!(
+                "{}, {:#?}, {:b}",
+                0.1f64,
+                vec![99, 1, 5, 100, 1, 0, 8],
+                0xffb1aa
+            )
         })
     }));
 }

--- a/benches/common/mod.rs
+++ b/benches/common/mod.rs
@@ -1,8 +1,7 @@
+use init_logger;
 use std::panic;
 use test::Bencher;
-
 use util::with_redirected_stderr;
-use init_logger;
 
 #[bench]
 fn simple_string(b: &mut Bencher) {

--- a/benches/junk_modules.rs
+++ b/benches/junk_modules.rs
@@ -1,7 +1,7 @@
 #![feature(test)]
-extern crate test;
-extern crate stderrlog;
 extern crate libc;
+extern crate stderrlog;
+extern crate test;
 
 #[macro_use]
 extern crate log;
@@ -24,6 +24,7 @@ fn init_logger() {
             .timestamp(stderrlog::Timestamp::Second)
             .verbosity(10)
             .modules(other_modules)
-            .init().unwrap();
+            .init()
+            .unwrap();
     });
 }

--- a/benches/no_color.rs
+++ b/benches/no_color.rs
@@ -1,7 +1,7 @@
 #![feature(test)]
-extern crate test;
-extern crate stderrlog;
 extern crate libc;
+extern crate stderrlog;
+extern crate test;
 
 #[macro_use]
 extern crate log;
@@ -21,6 +21,7 @@ fn init_logger() {
             .verbosity(10)
             .color(termcolor::ColorChoice::Never)
             .module(module_path!())
-            .init().unwrap();
+            .init()
+            .unwrap();
     });
 }

--- a/benches/quiet.rs
+++ b/benches/quiet.rs
@@ -1,7 +1,7 @@
 #![feature(test)]
-extern crate test;
-extern crate stderrlog;
 extern crate libc;
+extern crate stderrlog;
+extern crate test;
 
 #[macro_use]
 extern crate log;
@@ -20,6 +20,7 @@ fn init_logger() {
             .verbosity(10)
             .quiet(true)
             .module(module_path!())
-            .init().unwrap();
+            .init()
+            .unwrap();
     });
 }

--- a/benches/real_calls.rs
+++ b/benches/real_calls.rs
@@ -1,7 +1,7 @@
 #![feature(test)]
-extern crate test;
-extern crate stderrlog;
 extern crate libc;
+extern crate stderrlog;
+extern crate test;
 
 #[macro_use]
 extern crate log;
@@ -19,6 +19,7 @@ fn init_logger() {
             .timestamp(stderrlog::Timestamp::Second)
             .verbosity(10)
             .module(module_path!())
-            .init().unwrap();
+            .init()
+            .unwrap();
     });
 }

--- a/benches/skip_module.rs
+++ b/benches/skip_module.rs
@@ -1,7 +1,7 @@
 #![feature(test)]
-extern crate test;
-extern crate stderrlog;
 extern crate libc;
+extern crate stderrlog;
+extern crate test;
 
 #[macro_use]
 extern crate log;
@@ -23,6 +23,7 @@ fn init_logger() {
             .timestamp(stderrlog::Timestamp::Second)
             .verbosity(10)
             .modules(other_modules)
-            .init().unwrap();
+            .init()
+            .unwrap();
     });
 }

--- a/benches/util/mod.rs
+++ b/benches/util/mod.rs
@@ -1,7 +1,7 @@
-use std::panic;
+use libc;
 use std::fs::File;
 use std::os::unix::io::AsRawFd;
-use libc;
+use std::panic;
 
 pub fn with_redirected_stderr<T, F>(f: F) -> T
 where

--- a/examples/clap.rs
+++ b/examples/clap.rs
@@ -12,37 +12,45 @@ extern crate clap;
 extern crate log;
 extern crate stderrlog;
 
-use clap::{Arg, App};
+use clap::{App, Arg};
 use std::str::FromStr;
 
 fn main() {
     let m = App::new("stderrlog example")
         .version(crate_version!())
-        .arg(Arg::with_name("verbosity")
-             .short("v")
-             .multiple(true)
-             .help("Increase message verbosity"))
-        .arg(Arg::with_name("quiet")
-             .short("q")
-             .help("Silence all output"))
-        .arg(Arg::with_name("timestamp")
-             .short("t")
-             .help("prepend log lines with a timestamp")
-             .takes_value(true)
-             .possible_values(&["none", "sec", "ms", "ns"]))
+        .arg(
+            Arg::with_name("verbosity")
+                .short("v")
+                .multiple(true)
+                .help("Increase message verbosity"),
+        )
+        .arg(
+            Arg::with_name("quiet")
+                .short("q")
+                .help("Silence all output"),
+        )
+        .arg(
+            Arg::with_name("timestamp")
+                .short("t")
+                .help("prepend log lines with a timestamp")
+                .takes_value(true)
+                .possible_values(&["none", "sec", "ms", "ns"]),
+        )
         .get_matches();
 
     let verbose = m.occurrences_of("verbosity") as usize;
     let quiet = m.is_present("quiet");
-    let ts = m.value_of("timestamp").map(|v| {
-        stderrlog::Timestamp::from_str(v).unwrap_or_else(|_| {
-            clap::Error {
-                message: "invalid value for 'timestamp'".into(),
-                kind: clap::ErrorKind::InvalidValue,
-                info: None,
-            }.exit()
+    let ts = m.value_of("timestamp")
+        .map(|v| {
+            stderrlog::Timestamp::from_str(v).unwrap_or_else(|_| {
+                clap::Error {
+                    message: "invalid value for 'timestamp'".into(),
+                    kind: clap::ErrorKind::InvalidValue,
+                    info: None,
+                }.exit()
+            })
         })
-    }).unwrap_or(stderrlog::Timestamp::Off);
+        .unwrap_or(stderrlog::Timestamp::Off);
 
     stderrlog::new()
         .module(module_path!())

--- a/examples/docopt.rs
+++ b/examples/docopt.rs
@@ -31,7 +31,11 @@ fn main() {
         .and_then(|d| d.argv(env::args().into_iter()).decode())
         .unwrap_or_else(|e| e.exit());
 
-    stderrlog::new().verbosity(args.flag_v).quiet(args.flag_q).init().unwrap();
+    stderrlog::new()
+        .verbosity(args.flag_v)
+        .quiet(args.flag_q)
+        .init()
+        .unwrap();
 
     error!("error msg");
     warn!("warning msg");

--- a/examples/timestamp.rs
+++ b/examples/timestamp.rs
@@ -4,23 +4,29 @@ extern crate clap;
 extern crate log;
 extern crate stderrlog;
 
-use clap::{Arg, App};
+use clap::{App, Arg};
 
 fn main() {
     let m = App::new("stderrlog example")
         .version(crate_version!())
-        .arg(Arg::with_name("verbosity")
-             .short("v")
-             .multiple(true)
-             .help("Increase message verbosity"))
-        .arg(Arg::with_name("quiet")
-             .short("q")
-             .help("Silence all output"))
-        .arg(Arg::with_name("timestamp")
-             .short("t")
-             .help("prepend log lines with a timestamp")
-             .takes_value(true)
-             .possible_values(&["none", "sec", "ms", "ns"]))
+        .arg(
+            Arg::with_name("verbosity")
+                .short("v")
+                .multiple(true)
+                .help("Increase message verbosity"),
+        )
+        .arg(
+            Arg::with_name("quiet")
+                .short("q")
+                .help("Silence all output"),
+        )
+        .arg(
+            Arg::with_name("timestamp")
+                .short("t")
+                .help("prepend log lines with a timestamp")
+                .takes_value(true)
+                .possible_values(&["none", "sec", "ms", "ns"]),
+        )
         .get_matches();
 
     let verbose = m.occurrences_of("verbosity") as usize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,9 +226,8 @@ use std::fmt;
 use std::io::{self, Write};
 use std::str::FromStr;
 use termcolor::{Color, ColorSpec, StandardStream, WriteColor};
-use thread_local::CachedThreadLocal;
-
 pub use termcolor::ColorChoice;
+use thread_local::CachedThreadLocal;
 
 /// State of the timestampping in the logger.
 #[derive(Clone, Copy, Debug)]

--- a/tests/debug_level.rs
+++ b/tests/debug_level.rs
@@ -4,7 +4,11 @@ extern crate stderrlog;
 
 #[test]
 fn debug_level() {
-    stderrlog::new().module(module_path!()).verbosity(3).init().unwrap();
+    stderrlog::new()
+        .module(module_path!())
+        .verbosity(3)
+        .init()
+        .unwrap();
 
     error!("error msg");
     warn!("warning msg");
@@ -12,5 +16,5 @@ fn debug_level() {
     debug!("debug msg");
     trace!("trace msg");
 
-    assert_eq!(log::LogLevel::Debug, log::max_log_level())
+    assert_eq!(log::Level::Debug, log::max_level())
 }

--- a/tests/error_level.rs
+++ b/tests/error_level.rs
@@ -4,7 +4,11 @@ extern crate stderrlog;
 
 #[test]
 fn error_level() {
-    stderrlog::new().module(module_path!()).verbosity(0).init().unwrap();
+    stderrlog::new()
+        .module(module_path!())
+        .verbosity(0)
+        .init()
+        .unwrap();
 
     error!("error msg");
     warn!("warning msg");
@@ -12,5 +16,5 @@ fn error_level() {
     debug!("debug msg");
     trace!("trace msg");
 
-    assert_eq!(log::LogLevel::Error, log::max_log_level())
+    assert_eq!(log::Level::Error, log::max_level())
 }

--- a/tests/info_level.rs
+++ b/tests/info_level.rs
@@ -4,7 +4,11 @@ extern crate stderrlog;
 
 #[test]
 fn info_level() {
-    stderrlog::new().module(module_path!()).verbosity(2).init().unwrap();
+    stderrlog::new()
+        .module(module_path!())
+        .verbosity(2)
+        .init()
+        .unwrap();
 
     error!("error msg");
     warn!("warning msg");
@@ -12,5 +16,5 @@ fn info_level() {
     debug!("debug msg");
     trace!("trace msg");
 
-    assert_eq!(log::LogLevel::Info, log::max_log_level())
+    assert_eq!(log::Level::Info, log::max_level())
 }

--- a/tests/module_inclusion.rs
+++ b/tests/module_inclusion.rs
@@ -1,6 +1,6 @@
-extern crate stderrlog;
 #[macro_use]
 extern crate log;
+extern crate stderrlog;
 
 mod utils;
 
@@ -15,7 +15,7 @@ mod included_not {
         logger.module("module_inclusion::included");
         logger.verbosity(10);
         utils::set_logger(logger);
-        assert!(!log_enabled!(log::LogLevel::Error));
+        assert!(!log_enabled!(log::Level::Error));
     }
 }
 
@@ -32,7 +32,7 @@ mod included {
             logger.module("module_inclusion::included::a");
             logger.verbosity(10);
             utils::set_logger(logger);
-            assert!(log_enabled!(log::LogLevel::Error));
+            assert!(log_enabled!(log::Level::Error));
         }
         #[test]
         fn sub_and_supermodule_included() {
@@ -42,7 +42,7 @@ mod included {
             logger.module("module_inclusion::included");
             logger.verbosity(10);
             utils::set_logger(logger);
-            assert!(log_enabled!(log::LogLevel::Error));
+            assert!(log_enabled!(log::Level::Error));
         }
     }
 }

--- a/tests/module_inclusion.rs
+++ b/tests/module_inclusion.rs
@@ -5,9 +5,9 @@ extern crate stderrlog;
 mod utils;
 
 mod included_not {
-    use utils;
     use log;
     use stderrlog::StdErrLog;
+    use utils;
     #[test]
     fn including_module_with_substring_name() {
         utils::init();
@@ -21,9 +21,9 @@ mod included_not {
 
 mod included {
     mod b {
-        use utils;
         use log;
         use stderrlog::StdErrLog;
+        use utils;
         #[test]
         fn super_and_submodule_included() {
             utils::init();

--- a/tests/quiet_trace_level.rs
+++ b/tests/quiet_trace_level.rs
@@ -4,7 +4,12 @@ extern crate stderrlog;
 
 #[test]
 fn quiet_trace_level() {
-    stderrlog::new().module(module_path!()).verbosity(4).quiet(true).init().unwrap();
+    stderrlog::new()
+        .module(module_path!())
+        .verbosity(4)
+        .quiet(true)
+        .init()
+        .unwrap();
 
     error!("error msg");
     warn!("warning msg");
@@ -12,5 +17,5 @@ fn quiet_trace_level() {
     debug!("debug msg");
     trace!("trace msg");
 
-    assert_eq!(log::LogLevelFilter::Off, log::max_log_level())
+    assert_eq!(log::LevelFilter::Off, log::max_level())
 }

--- a/tests/trace_level.rs
+++ b/tests/trace_level.rs
@@ -4,7 +4,11 @@ extern crate stderrlog;
 
 #[test]
 fn trace_level() {
-    stderrlog::new().module(module_path!()).verbosity(4).init().unwrap();
+    stderrlog::new()
+        .module(module_path!())
+        .verbosity(4)
+        .init()
+        .unwrap();
 
     error!("error msg");
     warn!("warning msg");
@@ -12,5 +16,5 @@ fn trace_level() {
     debug!("debug msg");
     trace!("trace msg");
 
-    assert_eq!(log::LogLevel::Trace, log::max_log_level())
+    assert_eq!(log::Level::Trace, log::max_level())
 }

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,7 +1,7 @@
-use std::sync;
-use std::cell::RefCell;
-use stderrlog::StdErrLog;
 use log::{self, Log};
+use std::cell::RefCell;
+use std::sync;
+use stderrlog::StdErrLog;
 
 thread_local! {
     pub static LOGGER_INSTANCE: RefCell<Option<StdErrLog>> = RefCell::new(None);

--- a/tests/warn_level.rs
+++ b/tests/warn_level.rs
@@ -4,7 +4,11 @@ extern crate stderrlog;
 
 #[test]
 fn warn_level() {
-    stderrlog::new().module(module_path!()).verbosity(1).init().unwrap();
+    stderrlog::new()
+        .module(module_path!())
+        .verbosity(1)
+        .init()
+        .unwrap();
 
     error!("error msg");
     warn!("warning msg");
@@ -12,5 +16,5 @@ fn warn_level() {
     debug!("debug msg");
     trace!("trace msg");
 
-    assert_eq!(log::LogLevel::Warn, log::max_log_level())
+    assert_eq!(log::Level::Warn, log::max_level())
 }


### PR DESCRIPTION
I ran `cargo test` but otherwise haven't tested extensively; this *should*  work, though. I also ran `rustfmt` against it, which is what changed the whitespace in the tests. fixed #8 