### PR TITLE
pin versions to not break compat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.2.4-pre"
 
 [dependencies]
 chrono = "0.4"
-log = "0.3"
+log = "0.3, < 0.3.9"
 termcolor = "0.3.3"
 thread_local = "0.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ termcolor = "0.3.3"
 thread_local = "0.3"
 
 [dev-dependencies]
-clap = "2"
+clap = "~2.22.0"
 docopt = "0.6"
 rustc-serialize = "0.3"
 libc = "0.2"


### PR DESCRIPTION
This crate has promised Rust 1.13.0 in its 0.2.x series so don't break that.