### PR TITLE
Add an option to disable printing message level

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,7 +277,7 @@ impl FromStr for Timestamp {
 pub struct StdErrLog {
     verbosity: LevelFilter,
     quiet: bool,
-    levels: bool,
+    show_level: bool,
     timestamp: Timestamp,
     modules: Vec<String>,
     writer: CachedThreadLocal<RefCell<StandardStream>>,
@@ -289,7 +289,7 @@ impl fmt::Debug for StdErrLog {
         f.debug_struct("StdErrLog")
             .field("verbosity", &self.verbosity)
             .field("quiet", &self.quiet)
-            .field("levels", &self.levels)
+            .field("show_level", &self.show_level)
             .field("timestamp", &self.timestamp)
             .field("modules", &self.modules)
             .field("writer", &"stderr")
@@ -355,7 +355,7 @@ impl Log for StdErrLog {
             }
             Timestamp::Off => {}
         }
-        if self.levels {
+        if self.show_level {
             let _ = write!(writer, "{} - ", record.level());
         }
         let _ = writeln!(writer, "{}", record.args());
@@ -378,7 +378,7 @@ impl StdErrLog {
         StdErrLog {
             verbosity: LevelFilter::Error,
             quiet: false,
-            levels: true,
+            show_level: true,
             timestamp: Timestamp::Off,
             modules: Vec::new(),
             writer: CachedThreadLocal::new(),
@@ -407,8 +407,8 @@ impl StdErrLog {
     }
 
     /// Enables or disables the use of timestamps in log messages (default is true)
-    pub fn levels(&mut self, levels: bool) -> &mut StdErrLog {
-        self.levels = levels;
+    pub fn show_level(&mut self, levels: bool) -> &mut StdErrLog {
+        self.show_level = levels;
         self
     }
 

--- a/tests/no_levels_output.rs
+++ b/tests/no_levels_output.rs
@@ -1,0 +1,21 @@
+#[macro_use]
+extern crate log;
+extern crate stderrlog;
+
+#[test]
+fn no_levels_output() {
+    stderrlog::new()
+        .module(module_path!())
+        .verbosity(4)
+        .levels(false)
+        .init()
+        .unwrap();
+
+    error!("error msg");
+    warn!("warning msg");
+    info!("info msg");
+    debug!("debug msg");
+    trace!("trace msg");
+
+    assert_eq!(log::Level::Trace, log::max_level())
+}

--- a/tests/no_levels_output.rs
+++ b/tests/no_levels_output.rs
@@ -7,7 +7,7 @@ fn no_levels_output() {
     stderrlog::new()
         .module(module_path!())
         .verbosity(4)
-        .levels(false)
+        .show_level(false)
         .init()
         .unwrap();
 


### PR DESCRIPTION
You can say `.levels(false)` to disable log level prefixes in the messages. (The current behavior, that of levels being printed, is preserved as the default.)

This can be useful e. g. in command-line utilities where you usually just want messages to appear on stderr, without the "log levels" (which are an implementation detail arising from the choice to use `log` instead of `if` + `eprintln!`).