### PR TITLE
-Z minimal-versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,8 @@ is-it-maintained-open-issues = { repository = "cardoe/stderrlog-rs" }
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
-atty = "^0.2, <=0.2.11"
-chrono = "0.4"
+atty = "^0.2.6, <=0.2.11"
+chrono = "0.4.10"
 log = { version = "0.4.1", features = ["std"] }
 termcolor = "1.0"
 thread_local = "^0.3, <=0.3.4"


### PR DESCRIPTION
I'm trying to test my crate for compatibility with `-Z minimal-versions`, and `stderrlog` pulls in seriously outdated pre-Rust-1.0 transitive dependencies.