### PR TITLE
Update deps and msrv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ rust:
   - stable
   - 1.31.0 # minimum supported version
 script:
-  - if [ ${TRAVIS_RUST_VERSION} = "nightly" ]; then
-      cargo generate-lockfile -Z minimal-versions;
+  - if [ ${TRAVIS_RUST_VERSION} = "1.31.0" ]; then
+      cargo generate-lockfile;
+      cargo +nightly update -Z minimal-versions;
     else
       cargo generate-lockfile;
     fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 0.5.0
 ### Changed
-- bumped minimum Rust version to 1.31.0 to match the log crate
+- bumped minimum Rust version to 1.31.0
+  * 1.16.0 fails on current version of some deps and some crates.io fetches
+  * Log crate 0.4.9 raised its MSRV to 1.31.0 (but is currently yanked)
 
 ## 0.4.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## 0.5.0
 ### Changed
-- bumped minimum Rust version to 1.31.0
+- Bumped minimum Rust version to 1.31.0
   * 1.16.0 fails on current version of some deps and some crates.io fetches
-  * Log crate 0.4.9 raised its MSRV to 1.31.0 (but is currently yanked)
+  * Log crate 0.4.11 raised its MSRV to 1.31.0
+- Updated and checked minimum version of all deps
+- Switched to rust edition 2018
+- Improved CI testing
 
 ## 0.4.3
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT/Apache-2.0"
 name = "stderrlog"
 readme = "README.md"
 repository = "https://github.com/cardoe/stderrlog-rs"
-version = "0.4.4-alpha.0"
+version = "0.5.0-alpha.0"
 edition = "2018"
 
 [badges]
@@ -22,7 +22,7 @@ maintenance = { status = "passively-maintained" }
 [dependencies]
 atty = "^0.2.6"
 chrono = "0.4.10"
-log = { version = "0.4.1", features = ["std"] }
+log = { version = "0.4.11", features = ["std"] }
 termcolor = "~1.1"
 thread_local = "~1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ is-it-maintained-open-issues = { repository = "cardoe/stderrlog-rs" }
 maintenance = { status = "passively-maintained" }
 
 [dependencies]
-atty = "^0.2.6, <=0.2.11"
+atty = "^0.2.6"
 chrono = "0.4.10"
 log = { version = "0.4.1", features = ["std"] }
 termcolor = "~1.1"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For example binaries showing how
 
 * `stderrlog` 0.5.x supports
   1) Rust 1.31.0 and newer
-  2) `log` >= 0.4.1
+  2) `log` >= 0.4.11
 * `stderrlog` 0.4.x supports
   1) Rust 1.16.0 and newer
   2) `log` >= 0.4.1

--- a/examples/large-example/Cargo.toml
+++ b/examples/large-example/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["Doug Goldstein <cardoe@cardoe.com>"]
 edition = "2018"
 
 [dependencies]
-log = "0.4.1"
+log = "0.4.11"
 stderrlog = { path = "../../" }
 structopt = "0.3"

--- a/examples/large-example/Cargo.toml
+++ b/examples/large-example/Cargo.toml
@@ -5,6 +5,6 @@ authors = ["Doug Goldstein <cardoe@cardoe.com>"]
 edition = "2018"
 
 [dependencies]
-log = "0.4"
+log = "0.4.1"
 stderrlog = { path = "../../" }
 structopt = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,8 +159,8 @@
 //!
 //! ### `log` Compatibility
 //!
-//! The 0.3.x versions of `stderrlog` aim to provide compatibility with
-//! applications using `log` 0.3.x
+//! The 0.4.x versions of `stderrlog` aim to provide compatibility with
+//! applications using `log` 0.4.1.
 //!
 //! ### Rust Compatibility
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![doc(html_root_url = "https://docs.rs/stderrlog/0.4.3")]
+#![doc(html_root_url = "https://docs.rs/stderrlog/0.5.0")]
 
 //! A simple logger to provide symantics similar to what is expected
 //! of most UNIX utilities by logging to stderr and the higher the
@@ -159,8 +159,8 @@
 //!
 //! ### `log` Compatibility
 //!
-//! The 0.4.x versions of `stderrlog` aim to provide compatibility with
-//! applications using `log` 0.4.1.
+//! The 0.5.x versions of `stderrlog` aim to provide compatibility with
+//! applications using `log` >= 0.4.11.
 //!
 //! ### Rust Compatibility
 //!


### PR DESCRIPTION
What started as a wish to fix #20 ended up as a larger deps and MSRV update (#22), plus fixing some bitrot. Nothing too scary, but the MSRV bump does imply a semver bump.

Rust 1.16 was 11 months old when it was chosen as the MSRV. The new MSRV (rust 1.32) is 16 months old and brings rust edition 2018, so it should have wide adoption at this stage.

I kept an eye on build/test/bench using both the MSRV and nightly compiler, as well as minimal dep versions. In the CI, I use minimal-versions with nightly only because I don't know whether `cargo +nightly update -Z minimal-version`  would succeed when `$TRAVIS_RUST_VERSION = 1.32.0`. If that's supported, it would be a better CI setup.

Thanks for the review.