### PR TITLE
adapt dependencies for fedora

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,11 +24,11 @@ atty = "^0.2.6"
 chrono = "0.4.10"
 log = { version = "0.4.11", features = ["std"] }
 termcolor = "~1.1"
-thread_local = "~1.0"
+thread_local = "1.0"
 
 [dev-dependencies]
 clap = "~2.33.0"
-docopt = "~1.0"
+docopt = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 libc = "0.2.18"
 structopt = "0.2.11"


### PR DESCRIPTION
Hi @cardoe

I am in the process to package your crate in fedora. They would like to relax these two dependencies to be able to make it work in fedora.
You can see the discussion here: https://bugzilla.redhat.com/show_bug.cgi?id=1966393