### PR TITLE
update thread_local from ~1.0 to ~1.1 and fix deprecation warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ atty = "^0.2.6"
 chrono = "0.4.10"
 log = { version = "0.4.11", features = ["std"] }
 termcolor = "~1.1"
-thread_local = "~1.0"
+thread_local = "~1.1"
 
 [dev-dependencies]
 clap = "~2.33.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,7 +210,7 @@ use std::str::FromStr;
 use termcolor::{Color, ColorSpec, StandardStream, WriteColor};
 
 pub use termcolor::ColorChoice;
-use thread_local::CachedThreadLocal;
+use thread_local::ThreadLocal;
 
 /// State of the timestampping in the logger.
 #[derive(Clone, Copy, Debug)]
@@ -258,7 +258,7 @@ pub struct StdErrLog {
     show_level: bool,
     timestamp: Timestamp,
     modules: Vec<String>,
-    writer: CachedThreadLocal<RefCell<StandardStream>>,
+    writer: ThreadLocal<RefCell<StandardStream>>,
     color_choice: ColorChoice,
     show_module_names: bool,
 }
@@ -281,7 +281,7 @@ impl Clone for StdErrLog {
     fn clone(&self) -> StdErrLog {
         StdErrLog {
             modules: self.modules.clone(),
-            writer: CachedThreadLocal::new(),
+            writer: ThreadLocal::new(),
             ..*self
         }
     }
@@ -366,7 +366,7 @@ impl StdErrLog {
             show_level: true,
             timestamp: Timestamp::Off,
             modules: Vec::new(),
-            writer: CachedThreadLocal::new(),
+            writer: ThreadLocal::new(),
             color_choice: ColorChoice::Auto,
             show_module_names: false,
         }

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -7,7 +7,7 @@ thread_local! {
     pub static LOGGER_INSTANCE: RefCell<Option<StdErrLog>> = RefCell::new(None);
 }
 
-static INIT_LOGGER: sync::Once = sync::ONCE_INIT;
+static INIT_LOGGER: sync::Once = sync::Once::new();
 
 struct DelegatingLogger;
 


### PR DESCRIPTION
CachedThreadLocal have been deprecated in 1.1.0, see: https://docs.rs/thread_local/latest/thread_local/struct.CachedThreadLocal.html

ONCE_INIT deprecation notice here: https://doc.rust-lang.org/std/sync/constant.ONCE_INIT.html