### PR TITLE
update docopt from ~1.0 to ~1.1 and structopt from 0.2.11 to 0.3.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ thread_local = "~1.0"
 
 [dev-dependencies]
 clap = "~2.33.0"
-docopt = "~1.1"
+docopt = "1.1"
 serde = { version = "1.0", features = ["derive"] }
 libc = "0.2.18"
 structopt = "0.3.20"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ thread_local = "~1.0"
 
 [dev-dependencies]
 clap = "~2.33.0"
-docopt = "~1.0"
+docopt = "~1.1"
 serde = { version = "1.0", features = ["derive"] }
 libc = "0.2.18"
-structopt = "0.2.11"
+structopt = "0.3.20"


### PR DESCRIPTION
Ref: https://salsa.debian.org/rust-team/debcargo-conf/-/commit/a64c5d1a365974e0b64c5b386799deed7e6c28fe