### PR TITLE
attempt to fix build broken by 4ffd89856

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 env:
   CARGO_TERM_COLOR: always
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         rust:
           - rust: stable
             command: test
-          - rust: 1.31.0
+          - rust: 1.36.0
             command: check
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## 0.6.0
+### Changed
+- Bumped the minimum Rust version to 1.36.0
+  * [RUSTSEC-2022-0006](https://rustsec.org/advisories/RUSTSEC-2022-0006.html) fixed
+
 ## 0.5.1
 ### Added
 - added `.show_module_names()` to include module name in output

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build status](https://ci.appveyor.com/api/projects/status/no8slwtoy5va0w4g/branch/master?svg=true)](https://ci.appveyor.com/project/cardoe/stderrlog-rs/branch/master)
 [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/cardoe/stderrlog-rs.svg)](http://isitmaintained.com/project/cardoe/stderrlog-rs "Average time to resolve an issue")
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/cardoe/stderrlog-rs.svg)](http://isitmaintained.com/project/cardoe/stderrlog-rs "Percentage of issues still open")
-[![Rust version]( https://img.shields.io/badge/rust-1.31.0+-blue.svg)]()
+[![Rust version]( https://img.shields.io/badge/rust-1.36.0+-blue.svg)]()
 [![Documentation](https://docs.rs/stderrlog/badge.svg)](https://docs.rs/stderrlog)
 [![Latest version](https://img.shields.io/crates/v/stderrlog.svg)](https://crates.io/crates/stderrlog)
 [![All downloads](https://img.shields.io/crates/d/stderrlog.svg)](https://crates.io/crates/stderrlog)
@@ -24,8 +24,11 @@ For example binaries showing how
 
 ## Supported Versions
 
+* `stderrlog` 0.6.x supports
+  1) Rust 1.36.0 and newer
+  2) `log` >= 0.4.11
 * `stderrlog` 0.5.x supports
-  1) Rust 1.31.0 and newer
+  1) Rust 1.36.0 and newer
   2) `log` >= 0.4.11
 * `stderrlog` 0.4.x supports
   1) Rust 1.16.0 and newer

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![doc(html_root_url = "https://docs.rs/stderrlog/0.5.0")]
+#![doc(html_root_url = "https://docs.rs/stderrlog/0.6.0")]
 
 //! A simple logger to provide symantics similar to what is expected
 //! of most UNIX utilities by logging to stderr and the higher the
@@ -169,7 +169,7 @@
 //! Bumping the minimum version of Rust is a minor breaking
 //! change and requires a minor version to be bumped.
 //!
-//! The minimum supported Rust version for this release is 1.31.0.
+//! The minimum supported Rust version for this release is 1.36.0.
 //!
 //! ### Module Level Logging
 //!


### PR DESCRIPTION
In 4ffd89856 the build is broken due to thread_local pulling in a
version of once_cell that doesn't work with the MSRV.