### PR TITLE
document verbosity and allow it to be specified differently

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,6 +373,13 @@ impl StdErrLog {
     }
 
     /// Sets the verbosity level of messages that will be displayed
+    ///
+    /// Values map as follows:
+    /// 0 -> Error
+    /// 1 -> Warn
+    /// 2 -> Info
+    /// 3 -> Debug
+    /// 4 or higher -> Trace
     pub fn verbosity(&mut self, verbosity: usize) -> &mut StdErrLog {
         let log_lvl = match verbosity {
             0 => LevelFilter::Error,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -357,6 +357,52 @@ impl Log for StdErrLog {
     }
 }
 
+pub enum LogLevelNum {
+    Off,
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl From<usize> for LogLevelNum {
+    fn from(verbosity: usize) -> Self {
+        match verbosity {
+            0 => LogLevelNum::Error,
+            1 => LogLevelNum::Warn,
+            2 => LogLevelNum::Info,
+            3 => LogLevelNum::Debug,
+            _ => LogLevelNum::Trace,
+        }
+    }
+}
+
+impl From<Level> for LogLevelNum {
+    fn from(l: Level) -> Self {
+        match l {
+            Level::Error => LogLevelNum::Error,
+            Level::Warn => LogLevelNum::Warn,
+            Level::Info => LogLevelNum::Info,
+            Level::Debug => LogLevelNum::Debug,
+            Level::Trace => LogLevelNum::Trace,
+        }
+    }
+}
+
+impl From<LevelFilter> for LogLevelNum {
+    fn from(l: LevelFilter) -> Self {
+        match l {
+            LevelFilter::Off => LogLevelNum::Off,
+            LevelFilter::Error => LogLevelNum::Error,
+            LevelFilter::Warn => LogLevelNum::Warn,
+            LevelFilter::Info => LogLevelNum::Info,
+            LevelFilter::Debug => LogLevelNum::Debug,
+            LevelFilter::Trace => LogLevelNum::Trace,
+        }
+    }
+}
+
 impl StdErrLog {
     /// creates a new stderr logger
     pub fn new() -> StdErrLog {
@@ -374,22 +420,27 @@ impl StdErrLog {
 
     /// Sets the verbosity level of messages that will be displayed
     ///
+    /// Values can be supplied as:
+    /// - usize
+    /// - log::Level
+    /// - log::LevelFilter
+    /// - LogLevelNum
+    ///
     /// Values map as follows:
     /// 0 -> Error
     /// 1 -> Warn
     /// 2 -> Info
     /// 3 -> Debug
     /// 4 or higher -> Trace
-    pub fn verbosity(&mut self, verbosity: usize) -> &mut StdErrLog {
-        let log_lvl = match verbosity {
-            0 => LevelFilter::Error,
-            1 => LevelFilter::Warn,
-            2 => LevelFilter::Info,
-            3 => LevelFilter::Debug,
-            _ => LevelFilter::Trace,
+    pub fn verbosity<V: Into<LogLevelNum>>(&mut self, verbosity: V) -> &mut StdErrLog {
+        self.verbosity = match verbosity.into() {
+            LogLevelNum::Off => LevelFilter::Off,
+            LogLevelNum::Error => LevelFilter::Error,
+            LogLevelNum::Warn => LevelFilter::Warn,
+            LogLevelNum::Info => LevelFilter::Info,
+            LogLevelNum::Debug => LevelFilter::Debug,
+            LogLevelNum::Trace => LevelFilter::Trace,
         };
-
-        self.verbosity = log_lvl;
         self
     }
 

--- a/tests/debug_level_log.rs
+++ b/tests/debug_level_log.rs
@@ -1,11 +1,11 @@
 use log::*;
 
 #[test]
-fn debug_level() {
+fn debug_level_log() {
     stderrlog::new()
         .module(module_path!())
-        .timestamp(stderrlog::Timestamp::Second)
-        .verbosity(3)
+        .timestamp(stderrlog::Timestamp::Nanosecond)
+        .verbosity(log::Level::Debug)
         .init()
         .unwrap();
 

--- a/tests/error_level.rs
+++ b/tests/error_level.rs
@@ -4,6 +4,7 @@ use log::*;
 fn error_level() {
     stderrlog::new()
         .module(module_path!())
+        .timestamp(stderrlog::Timestamp::Millisecond)
         .verbosity(0)
         .init()
         .unwrap();

--- a/tests/info_level.rs
+++ b/tests/info_level.rs
@@ -4,6 +4,7 @@ use log::*;
 fn info_level() {
     stderrlog::new()
         .module(module_path!())
+        .timestamp(stderrlog::Timestamp::Microsecond)
         .verbosity(2)
         .init()
         .unwrap();

--- a/tests/quiet_trace_level.rs
+++ b/tests/quiet_trace_level.rs
@@ -4,6 +4,7 @@ use log::*;
 fn quiet_trace_level() {
     stderrlog::new()
         .module(module_path!())
+        .timestamp(stderrlog::Timestamp::Second)
         .verbosity(4)
         .quiet(true)
         .init()


### PR DESCRIPTION
Allow users to specify the verbosity with the levels from the log crate as well as the numerical values used today. Document the numerical values used today as well. fixes #28. fixes #32.