### PR TITLE
Add missing field to `StdErrLog` debug implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## Unreleased
+### Changed
+- Added missing `show_module_names` field to `StdErrLog` debug implementation.
+
 ## 0.5.2
 ### Changed
 - Bumped the minimum Rust version to 1.36.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,6 +273,7 @@ impl fmt::Debug for StdErrLog {
             .field("modules", &self.modules)
             .field("writer", &"stderr")
             .field("color_choice", &self.color_choice)
+            .field("show_module_names", &self.show_module_names)
             .finish()
     }
 }


### PR DESCRIPTION
The `show_module_names` field was missing from the manual `Debug` implementation for `StdErrLog`.