### PR TITLE
Support disabling the timestamps feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 ### Changed
+- Moved the timestamps feature behind the enabled-by-default crate feature `timestamps`.
 - Added missing `show_module_names` field to `StdErrLog` debug implementation.
 
 ## 0.5.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ maintenance = { status = "passively-maintained" }
 
 [dependencies]
 atty = "^0.2.6"
-chrono = "0.4.10"
+chrono = { version = "0.4.10", optional = true }
 log = { version = "0.4.11", features = ["std"] }
 termcolor = "~1.1"
 thread_local = "~1.1"
@@ -32,3 +32,7 @@ docopt = "1.1"
 serde = { version = "1.0", features = ["derive"] }
 libc = "0.2.18"
 structopt = "0.3.20"
+
+[features]
+default = ["timestamps"]
+timestamps = ["chrono"]


### PR DESCRIPTION
The timestamps feature of `stderrlog` relies upon the `chrono` crate, which:
(a) means pulling in an additional 5 dependencies,
(b) has had CVE related issues of late (eg #31).

Now, a new crate feature `timestamps` has been added, which is enabled by default, but can be switched off using `default-features = false` should consumers of `stderrlog` not use timestamps and want to reduce the size of the dependency tree + security scan false positives.