### PR TITLE
Disable "oldtime" feature of chrono

### DIFF
--- a/Cargo.lock.msrv
+++ b/Cargo.lock.msrv
@@ -60,7 +60,6 @@ dependencies = [
  "js-sys 0.3.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-integer 0.1.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -395,16 +394,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.137 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasi 0.10.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,11 +416,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "version_check"
 version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -557,13 +541,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum termcolor 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
-"checksum time 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 "checksum unicode-ident 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 "checksum unicode-segmentation 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
 "checksum unicode-width 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 "checksum vec_map 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 "checksum version_check 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-"checksum wasi 0.10.0+wasi-snapshot-preview1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 "checksum wasm-bindgen 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)" = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 "checksum wasm-bindgen-backend 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)" = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
 "checksum wasm-bindgen-macro 0.2.83 (registry+https://github.com/rust-lang/crates.io-index)" = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ maintenance = { status = "passively-maintained" }
 
 [dependencies]
 atty = "^0.2.6"
-chrono = { version = "0.4.10", optional = true }
+chrono = { version = "0.4.10", optional = true, default-features = false, features = ["clock", "std", "wasmbind"] }
 log = { version = "0.4.11", features = ["std"] }
 termcolor = "~1.1"
 thread_local = "~1.1"


### PR DESCRIPTION
The "oldtime" feature of the chrono crate depends on a version of the time crate affected by RUSTSEC-2020-0071.

It does not appear that stderrlog depends on functionality provided by this feature.