### PR TITLE
fix: Clap error in examples/timestamp

### DIFF
--- a/examples/timestamp.rs
+++ b/examples/timestamp.rs
@@ -7,7 +7,7 @@ fn main() {
         .arg(
             Arg::with_name("verbosity")
                 .short('v')
-                .multiple(true)
+                .multiple_occurrences(true)
                 .help("Increase message verbosity"),
         )
         .arg(


### PR DESCRIPTION
Currently, examples/timestamp raises runtime error by violation of constraints of clap.

```
$ cargo run --example timestamp
   Compiling stderrlog v0.5.5-alpha.0 (/home/keno/src/github.com/cardoe/stderrlog-rs)
    Finished dev [unoptimized + debuginfo] target(s) in 0.52s
     Running `target/debug/examples/timestamp`
thread 'main' panicked at 'Argument "verbosity"
  Arg::is_takes_value_set is required when Arg::is_multiple_values_set is set.
', /home/keno/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-3.2.23/src/builder/debug_asserts.rs:746:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

`Arg::multiple()` is deprecated in clap 3.* [1].
This PR uses `Arg::multiple_occurrences()` instead and fixes the error.

[1] https://docs.rs/clap/3.0.0/clap/struct.Arg.html#method.multiple